### PR TITLE
removed import line_detector2.py

### DIFF
--- a/catkin_ws/src/sw06-CV/packages/sw_06_line_detector/include/sw_06_line_detector/__init__.py
+++ b/catkin_ws/src/sw06-CV/packages/sw_06_line_detector/include/sw_06_line_detector/__init__.py
@@ -1,2 +1,1 @@
 from .line_detector1 import *
-from .line_detector2 import *


### PR DESCRIPTION
Fixed "ImportError: No module named line_detector2" when running "roslaunch sw_06_line_detector lane_following.launch"