### PR TITLE
Update lane_filter.py

### DIFF
--- a/catkin_ws/src/sw07-SE/packages/sw_07_lane_filter/include/sw_07_lane_filter/lane_filter.py
+++ b/catkin_ws/src/sw07-SE/packages/sw_07_lane_filter/include/sw_07_lane_filter/lane_filter.py
@@ -15,8 +15,6 @@ import numpy as np
 
 from .lane_filter_interface import LaneFilterInterface
 
-from .visualization import plot_phi_d_diagram_bgr
-
 from scipy.stats import multivariate_normal
 from scipy.ndimage.filters import gaussian_filter
 from math import floor, sqrt


### PR DESCRIPTION
fixed "ImportError: No module named visualization" when running "roslaunch sw_07_lane_filter lane_following.launch"