### PR TITLE
Update __init__.py

### DIFF
--- a/catkin_ws/src/sw07-SE/packages/sw_07_lane_filter/include/sw_07_lane_filter/__init__.py
+++ b/catkin_ws/src/sw07-SE/packages/sw_07_lane_filter/include/sw_07_lane_filter/__init__.py
@@ -1,6 +1,5 @@
 FAMILY_LANE_FILTER = 'lane_filter'
 
 from .lane_filter import *
-from .lane_filter_classic import *
 from .lane_filter_interface import *
 


### PR DESCRIPTION
fixed "ImportError: No module named lane_filter_classic" when running "roslaunch sw_07_lane_filter lane_following.launch"